### PR TITLE
Fix null-terminated selector text

### DIFF
--- a/SELECTOR.CPP
+++ b/SELECTOR.CPP
@@ -337,7 +337,9 @@ void TSelector::Reset()
 void TSelector::SetText(char *TextString)
 {
   // Sets the window text to that specified in TextString
-  strncpy(MainText, TextString, 4);
+  // Ensure the string is always NUL terminated
+  strncpy(MainText, TextString, sizeof(MainText) - 1);
+  MainText[sizeof(MainText) - 1] = '\0';
 }
 
 


### PR DESCRIPTION
## Summary
- ensure `TSelector::SetText` always writes a NUL terminator

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68595ad5e048832aa1d7a3bae4f27ca5